### PR TITLE
Fix wrong argument checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,8 @@ install:
     - export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python${MB_PYTHON_VERSION}/site-packages
     - export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python${MB_PYTHON_VERSION}/dist-packages
     - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
-    - pip install setuptools setuptools-scm
+    - easy_install --upgrade pip
+    - pip install setuptools
     - pip install -r requirements.txt
     - git clone --recursive https://github.com/Statoil/libecl.git
     - mkdir libecl/build

--- a/python/nex/_nex2ecl/nex2ecl.py
+++ b/python/nex/_nex2ecl/nex2ecl.py
@@ -95,7 +95,7 @@ def nex2ecl(
     field_names = plt[plt['classname'] == 'FIELD'].instancename.unique()
     if len(field_names) > 1 and not field_name:
         raise ConversionError('More than one field in plot', 1)
-    if len(field_names) > 0 and field_name not in field_names:
+    if field_name and len(field_names) > 0 and field_name not in field_names:
         raise ConversionError('{} not in plot'.format(field_name), 2)
 
     if warn and len(field_names) > 1:


### PR DESCRIPTION
Currently if there is more than zero fields in the nexus plot, the
implementation required that a field was specified. This is a mistake,
as it is supposed to accept nexus plots that contain exactly one field
without a specified field.